### PR TITLE
Proto2Thrift enhancements:

### DIFF
--- a/exe/main.go
+++ b/exe/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	pbThrift "github.com/YYCoder/protobuf-thrift"
-	"github.com/YYCoder/protobuf-thrift/utils/logger"
+	pbThrift "github.com/kevinzfb/protobuf-thrift"
+	"github.com/kevinzfb/protobuf-thrift/utils/logger"
 )
 
 func main() {

--- a/generator.go
+++ b/generator.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/YYCoder/protobuf-thrift/utils/logger"
+	"github.com/kevinzfb/protobuf-thrift/utils/logger"
 )
 
 // Represent a file need to be converted, including current absolute path and absolute converted output path
@@ -228,6 +228,12 @@ func (g *generator) initSubGenerator(fileInfos []FileInfo) (err error) {
 				fieldCase:      g.conf.FieldCase,
 				nameCase:       g.conf.NameCase,
 				syntax:         g.conf.Syntax,
+
+				//[kevinzfb] added configs
+				addUnknownToEnums: g.conf.AddUnknownToEnums,
+				namespace:         g.conf.Namespace,
+				namespaceLangs:    g.conf.NamespaceLangs,
+				enumCase:          g.conf.EnumCase,
 			}
 			generator, err = NewThriftGenerator(conf)
 			if err != nil {
@@ -277,6 +283,12 @@ func (g *generator) initSubGeneratorForRawContent() (err error) {
 			fieldCase:      g.conf.FieldCase,
 			nameCase:       g.conf.NameCase,
 			syntax:         g.conf.Syntax,
+
+			//[kevinzfb] added configs
+			addUnknownToEnums: g.conf.AddUnknownToEnums,
+			namespace:         g.conf.Namespace,
+			namespaceLangs:    g.conf.NamespaceLangs,
+			enumCase:          g.conf.EnumCase,
 		}
 		generator, err = NewThriftGenerator(conf)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/YYCoder/protobuf-thrift
+module github.com/kevinzfb/protobuf-thrift
 
 go 1.16
 

--- a/thrift-2-proto-gen.go
+++ b/thrift-2-proto-gen.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/YYCoder/protobuf-thrift/utils"
-	"github.com/YYCoder/protobuf-thrift/utils/logger"
+	"github.com/kevinzfb/protobuf-thrift/utils"
+	"github.com/kevinzfb/protobuf-thrift/utils/logger"
 	"github.com/YYCoder/thrifter"
 )
 


### PR DESCRIPTION
1. Convert `bytes` in proto to `binary` in Thrift.
2. Convert unsigned ints to their signed equivalents.
3. Add a language flag (default *) to be able to specify languages in the Thrift namespace.
4. Add an `enumCase` flag (default screamingSnakeCase) for enum members
5. Add a flag for adding an "UNKNOWN" value in every enum
6. Add a flag for specifying a new namespace